### PR TITLE
Add WPML compatibility for wordpress functions

### DIFF
--- a/includes/feed-sitemap-news.php
+++ b/includes/feed-sitemap-news.php
@@ -7,7 +7,7 @@
 
 if ( ! defined( 'WPINC' ) ) die;
 
-global $xmlsf;
+global $xmlsf, $sitepress;
 $options = $xmlsf->get_option('news_tags');
 
 status_header('200'); // force header('HTTP/1.1 200 OK') for sites without posts
@@ -44,7 +44,12 @@ $have_posts = false;
 if ( have_posts() ) :
     while ( have_posts() ) :
 	the_post();
-
+	// WPML: switch language 
+        // @see https://wpml.org/wpml-hook/wpml_post_language_details/
+        if( isset($sitepress) ){
+            $post_language = apply_filters( 'wpml_post_language_details', NULL, $post->ID );
+            $sitepress->switch_lang($post_language['language_code']);
+        }
 	// check if we are not dealing with an external URL :: Thanks to Francois Deschenes :)
 	// or if post meta says "exclude me please"
 	$exclude = get_post_meta( $post->ID, '_xmlsf_news_exclude', true );

--- a/includes/feed-sitemap-post_type.php
+++ b/includes/feed-sitemap-post_type.php
@@ -19,7 +19,7 @@ echo '<?xml version="1.0" encoding="' . get_bloginfo('charset') . '"?>
 <!-- generator-version="' . XMLSF_VERSION . '" -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ';
 
-global $xmlsf;
+global $xmlsf, $sitepress;
 $post_type = get_query_var('post_type');
 
 foreach ( $xmlsf->do_tags($post_type) as $tag => $setting )
@@ -47,7 +47,12 @@ $have_posts = false;
 if ( have_posts() ) :
     while ( have_posts() ) :
 	the_post();
-
+	// WPML Compat
+        // @see https://wpml.org/wpml-hook/wpml_post_language_details/
+        if( isset($sitepress) ){
+            $post_language = apply_filters( 'wpml_post_language_details', NULL, $post->ID );
+            $sitepress->switch_lang($post_language['language_code']);
+        }
 	// check if page is in the exclusion list (like front page)
 	// or if we are not dealing with an external URL :: Thanks to Francois Deschenes :)
 	// or if post meta says "exclude me please"

--- a/includes/feed-sitemap-taxonomy.php
+++ b/includes/feed-sitemap-taxonomy.php
@@ -23,10 +23,13 @@ echo '<?xml version="1.0" encoding="'.get_bloginfo('charset', 'UTF-8').'"?>
 		http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 ';
 
-global $xmlsf;
+global $xmlsf, $sitepress;
 
 $taxonomy = get_query_var('taxonomy');
-
+// WPML compat
+if( isset($sitepress) ){
+    $sitepress->switch_lang('all');
+}
 $terms = get_terms( $taxonomy, array(
 					'orderby' => 'count',
 					'order' => 'DESC',


### PR DESCRIPTION
WPML heavily filters normal Wordpress functions such as get_permalink() to force them to use the current language according to the request. Because this loop contains posts from all languages, we tell WPML to switch to the language of the current post within the loop.
